### PR TITLE
Change date validation to strict

### DIFF
--- a/src/main/java/seedu/phu/model/internship/Date.java
+++ b/src/main/java/seedu/phu/model/internship/Date.java
@@ -6,17 +6,19 @@ import static seedu.phu.commons.util.AppUtil.checkArgument;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.time.format.ResolverStyle;
 
 /**
  * Represents the date of an internship in the list.
  */
 public class Date extends ComparableModel {
     public static final String MESSAGE_CONSTRAINTS =
-            "Date should be in dd-mm-yyyy format";
+            "Date should be a valid date in dd-mm-yyyy format";
 
-    public static final DateTimeFormatter DEFAULT_FORMATTER = DateTimeFormatter.ofPattern("dd-MM-yyyy");
+    public static final DateTimeFormatter DEFAULT_FORMATTER =
+            DateTimeFormatter.ofPattern("dd-MM-uuuu").withResolverStyle(ResolverStyle.STRICT);
 
-    public static final DateTimeFormatter DISPLAY_FORMATTER = DateTimeFormatter.ofPattern("dd MMM yyyy");
+    public static final DateTimeFormatter DISPLAY_FORMATTER = DateTimeFormatter.ofPattern("dd MMM uuuu");
 
     public final LocalDate value;
 

--- a/src/test/java/seedu/phu/model/internship/DateTest.java
+++ b/src/test/java/seedu/phu/model/internship/DateTest.java
@@ -40,10 +40,14 @@ public class DateTest {
         assertFalse(Date.isValidDate("32-13-1212")); // invalid date
         assertFalse(Date.isValidDate("29-2-2022")); // month should be 2 digits
         assertFalse(Date.isValidDate("9-02-2022")); // date should be 2 digits
+        assertFalse(Date.isValidDate("31-11-2022")); // invalid date boundary
+        assertFalse(Date.isValidDate("29-02-2022")); // invalid date boundary
+        assertFalse(Date.isValidDate("00-02-2022")); // invalid date boundary
 
         // valid date
         assertTrue(Date.isValidDate("12-12-1212"));
-        assertTrue(Date.isValidDate("09-02-2022"));
-        assertTrue(Date.isValidDate("29-02-2022"));
+        assertTrue(Date.isValidDate("01-02-2022"));
+        assertTrue(Date.isValidDate("29-02-2024")); // leap year
+        assertTrue(Date.isValidDate("30-11-2024"));
     }
 }


### PR DESCRIPTION
Previous behavior: Any date from [1,31] will be accepted. Suppose the month does not have that date (e.g., 31 November 2022), then the maximum date will be taken instead (e.g., 30 November 2022).

Updated behavior: Check for the available date for each month (e.g., 31 November 2022 will result in an error).