### PR TITLE
Remark Validation (don't merge yet)

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -829,7 +829,7 @@ testers are expected to do more *exploratory* testing.
    2. Test case: `add n/Google p/Backend Intern`<br>
       Expected: An internship application is added to PHU internship list, with company name `Google`, position `Backend Intern`,
       date being today's date (by default), application process `APPLIED` (by default), phone `NA` (by default),
-      email `NA` (by default), website `NA` (by default), and empty remark. A success message is shown with the details
+      email `NA` (by default), website `NA` (by default), and remark `-` (by default). A success message is shown with the details
       of the added internship. The entire application list is displayed.
 
    3. Test case: `add n/Google`<br>

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -175,12 +175,13 @@ Format: `add n/COMPANY_NAME p/POSITION [pr/APPLICATION_PROCESS] [d/DATE] [ph/PHO
 * `PHONE` will be set to "NA" by default.
 * `EMAIL` will be set to "NA" by default.
 * `WEBSITE` will be set to “NA” by default. 
-* `WEBSITE` must start with `http://` or `https://`
-* `REMARK` will be empty by default.
-* `TAG` will be empty by default. All tags must be alphanumeric.
+* `WEBSITE` must start with `http://` or `https://`.
+* `REMARK` will be `-` by default.
+* `TAG` will be empty by default. 
+*  All tags must be alphanumeric.
 
 <div markdown="block" class="alert alert-success">
-**:bulb: Tip:** A person can have any number of tags (including 0)
+**:bulb: Tip:** An internship can have any number of tags (including 0)
 </div>
 
 Examples:

--- a/src/main/java/seedu/phu/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/phu/logic/parser/ParserUtil.java
@@ -78,6 +78,9 @@ public class ParserUtil {
     public static Remark parseRemark(String remark) throws ParseException {
         requireNonNull(remark);
         String trimmedRemark = remark.trim();
+        if (!Remark.isValidRemark(trimmedRemark)) {
+            throw new ParseException(Remark.MESSAGE_CONSTRAINTS);
+        }
         return new Remark(trimmedRemark);
     }
 

--- a/src/main/java/seedu/phu/model/internship/Remark.java
+++ b/src/main/java/seedu/phu/model/internship/Remark.java
@@ -7,7 +7,8 @@ import static java.util.Objects.requireNonNull;
  * Guarantees: immutable;
  */
 public class Remark {
-    public static final String DEFAULT_VALUE = "";
+    public static final String MESSAGE_CONSTRAINTS = "Remark should not be empty";
+    public static final String DEFAULT_VALUE = "-";
 
     public final String value;
 
@@ -19,6 +20,10 @@ public class Remark {
     public Remark(String remark) {
         requireNonNull(remark);
         value = remark;
+    }
+
+    public static boolean isValidRemark(String trimmedRemark) {
+        return !trimmedRemark.equals("");
     }
 
     @Override

--- a/src/test/java/seedu/phu/model/internship/RemarkTest.java
+++ b/src/test/java/seedu/phu/model/internship/RemarkTest.java
@@ -1,14 +1,28 @@
 package seedu.phu.model.internship;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.phu.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
 public class RemarkTest {
-
     @Test
     public void constructor_null_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> new Remark(null));
+    }
+
+    @Test
+    public void isValidRemark() {
+        assertThrows(NullPointerException.class, () -> Remark.isValidRemark(null));
+
+        // invalid remark
+        assertFalse(Remark.isValidRemark("")); // empty string
+
+        // valid remark
+        assertTrue(Remark.isValidRemark("-"));
+        assertTrue(Remark.isValidRemark("containing numbers 123"));
+        assertTrue(Remark.isValidRemark("Containing non-alphanumeric @ //"));
     }
 
 }


### PR DESCRIPTION
Change remark behavior to become consistent with tag. 
i.e. When `t/` is entered in the command but no tags is provided, an error message is displayed.

Previous behavior: `r/` is accepted, taking empty string as the parameter for remark.
Updated behavior: 
- `r/` is not accepted, an error message is displayed. 
- Default value for `r/` is modified to `-`. 
- Empty string (or spaces only) no longer accepted as parameter for remark.
