### PR TITLE
Fix web validation

### DIFF
--- a/src/main/java/seedu/phu/model/internship/Website.java
+++ b/src/main/java/seedu/phu/model/internship/Website.java
@@ -9,10 +9,10 @@ import static seedu.phu.commons.util.AppUtil.checkArgument;
 public class Website {
     public static final int MAX_LENGTH = 2048;
     public static final String VALIDATION_WITHOUT_PATH_REGEX =
-            "^https?://([a-zA-Z0-9]+[-.])+([a-zA-Z0-9]+[a-zA-Z])$";
+            "^https?://([a-zA-Z0-9]+[-.])*([a-zA-Z0-9]+[.])([a-zA-Z0-9]+[a-zA-Z])$";
 
     public static final String VALIDATION_WITH_PATH_REGEX =
-            "^https?://([a-zA-Z0-9]+[-.])+([a-zA-Z0-9]+[a-zA-Z]/)[-a-zA-Z0-9+;,/?:@&=$_.!~*'()#]*$";
+            "^https?://([a-zA-Z0-9]+[-.])*([a-zA-Z0-9]+[.])([a-zA-Z0-9]+[a-zA-Z]/)[-a-zA-Z0-9+;,/?:@&=$_.!~*'()#]*$";
 
     public static final String DEFAULT_VALUE = "NA";
     private static final String SPECIAL_CHARACTERS = ";,/?:@&=+$-_.!~*'()#";

--- a/src/main/java/seedu/phu/model/internship/Website.java
+++ b/src/main/java/seedu/phu/model/internship/Website.java
@@ -8,22 +8,6 @@ import static seedu.phu.commons.util.AppUtil.checkArgument;
  */
 public class Website {
     public static final int MAX_LENGTH = 2048;
-    private static final String SPECIAL_CHARACTERS = ";,/?:@&=+$-_.!~*'()#";
-    public static final String MESSAGE_CONSTRAINTS =
-            "Web must be of the format PROTOCOL://DOMAIN-NAME/PATH-QUERY-FRAGMENT"
-            + " and adhere to the following constraints:\n"
-            + "1. The protocol must either be \"https\" or \"http\".\n"
-            + "2. The domain name is made up of domain labels separated by periods.\n"
-            + "The domain name must:\n"
-            + "    - have at least 2 domain labels, with the last label being the top level domain label.\n"
-            + "    - have the top level domain label ends with an alphabet.\n"
-            + "    - have the top level domain label at least 2 characters long.\n"
-            + "    - have each domain label start and end with alphanumeric characters.\n"
-            + "    - have each domain label consist of alphanumeric characters, separated only by hyphens, if any.\n"
-            + "3. The path-query-fragment should only contain alphanumeric characters and these special "
-            + "characters, excluding the outer parentheses, ( "+ SPECIAL_CHARACTERS + ").\n"
-            + "4. Web must not exceed 2048 characters.";
-
     public static final String VALIDATION_WITHOUT_PATH_REGEX =
             "^https?://([a-zA-Z0-9]+[-.])+([a-zA-Z0-9]+[a-zA-Z])$";
 
@@ -31,6 +15,22 @@ public class Website {
             "^https?://([a-zA-Z0-9]+[-.])+([a-zA-Z0-9]+[a-zA-Z]/)[-a-zA-Z0-9+;,/?:@&=$_.!~*'()#]*$";
 
     public static final String DEFAULT_VALUE = "NA";
+    private static final String SPECIAL_CHARACTERS = ";,/?:@&=+$-_.!~*'()#";
+    public static final String MESSAGE_CONSTRAINTS =
+            "Website must be of the format PROTOCOL://DOMAIN-NAME/PATH-QUERY-FRAGMENT"
+            + " and adhere to the following constraints:\n"
+            + "1. The protocol must either be \"https\" or \"http\".\n"
+            + "2. The domain name is made up of domain labels separated by periods.\n"
+            + "The domain name must:\n"
+            + "    - have at least 2 domain labels, with the last label being the top level domain label.\n"
+            + "    - have the top level domain label ends with an alphabet.\n"
+            + "    - have the top level domain label at least 2 characters long.\n"
+            + "    - have the top level domain label separated from the other domain labels by a period.\n"
+            + "    - have each domain label start and end with alphanumeric characters.\n"
+            + "    - have each domain label consist of alphanumeric characters, separated only by hyphens, if any.\n"
+            + "3. The path-query-fragment should only contain alphanumeric characters and these special "
+            + "characters, excluding the outer parentheses, ( " + SPECIAL_CHARACTERS + ").\n"
+            + "4. Website must not exceed 2048 characters.";
 
     public final String value;
 

--- a/src/main/java/seedu/phu/model/internship/Website.java
+++ b/src/main/java/seedu/phu/model/internship/Website.java
@@ -7,13 +7,28 @@ import static seedu.phu.commons.util.AppUtil.checkArgument;
  * Represents the website of the company of the internship.
  */
 public class Website {
-    public static final String MESSAGE_CONSTRAINTS = "Web must be a URL";
+    public static final int MAX_LENGTH = 2048;
+    private static final String SPECIAL_CHARACTERS = ";,/?:@&=+$-_.!~*'()#";
+    public static final String MESSAGE_CONSTRAINTS =
+            "Web must be of the format PROTOCOL://DOMAIN-NAME/PATH-QUERY-FRAGMENT"
+            + " and adhere to the following constraints:\n"
+            + "1. The protocol must either be \"https\" or \"http\".\n"
+            + "2. The domain name is made up of domain labels separated by periods.\n"
+            + "The domain name must:\n"
+            + "    - have at least 2 domain labels, with the last label being the top level domain label.\n"
+            + "    - have the top level domain label ends with an alphabet.\n"
+            + "    - have the top level domain label at least 2 characters long.\n"
+            + "    - have each domain label start and end with alphanumeric characters.\n"
+            + "    - have each domain label consist of alphanumeric characters, separated only by hyphens, if any.\n"
+            + "3. The path-query-fragment should only contain alphanumeric characters and these special "
+            + "characters, excluding the outer parentheses, ( "+ SPECIAL_CHARACTERS + ").\n"
+            + "4. Web must not exceed 2048 characters.";
 
-    //@@author TomC-reused
-    //Reused from https://stackoverflow.com/questions/163360
-    public static final String VALIDATION_REGEX =
-            "^(https?|ftp|file)://[-a-zA-Z0-9+&@#/%?=~_|!:,.;]*[-a-zA-Z0-9+&@#/%=~_|]";
-    //@@author
+    public static final String VALIDATION_WITHOUT_PATH_REGEX =
+            "^https?://([a-zA-Z0-9]+[-.])+([a-zA-Z0-9]+[a-zA-Z])$";
+
+    public static final String VALIDATION_WITH_PATH_REGEX =
+            "^https?://([a-zA-Z0-9]+[-.])+([a-zA-Z0-9]+[a-zA-Z]/)[-a-zA-Z0-9+;,/?:@&=$_.!~*'()#]*$";
 
     public static final String DEFAULT_VALUE = "NA";
 
@@ -34,7 +49,8 @@ public class Website {
      * Returns true if a given string is a valid website.
      */
     public static boolean isValidWebsite(String test) {
-        return test.matches(VALIDATION_REGEX) || test.equals(DEFAULT_VALUE);
+        return test.length() <= MAX_LENGTH && (test.matches(VALIDATION_WITHOUT_PATH_REGEX)
+                || test.matches(VALIDATION_WITH_PATH_REGEX) || test.equals(DEFAULT_VALUE));
     }
 
     @Override

--- a/src/test/java/seedu/phu/model/internship/WebsiteTest.java
+++ b/src/test/java/seedu/phu/model/internship/WebsiteTest.java
@@ -28,12 +28,28 @@ public class WebsiteTest {
         assertFalse(Website.isValidWebsite(" ")); // spaces only
         assertFalse(Website.isValidWebsite("https:"));
         assertFalse(Website.isValidWebsite("https://"));
-        assertFalse(Website.isValidWebsite("www.google.com/jobs/results"));
+        assertFalse(Website.isValidWebsite("https:////"));
+        assertFalse(Website.isValidWebsite("file://careers.google.com/jobs/results")); // wrong protocol
+        assertFalse(Website.isValidWebsite("www.google.com/jobs/results")); // missing protocol
+        assertFalse(Website.isValidWebsite("https://example")); // missing top level domain
+        assertFalse(Website.isValidWebsite("https://example.c/careers")); // top level domain length less than 2
+        assertFalse(Website.isValidWebsite("https://example.11/careers")); // top level domain numbers only
+        assertFalse(Website.isValidWebsite("https://example.a1/careers")); // top level domain end with number
+        assertFalse(Website.isValidWebsite("https://example..eg.cc/careers")); // consecutive period
+        assertFalse(Website.isValidWebsite("https://example-.eg.cc/careers")); // consecutive special char
+        assertFalse(Website.isValidWebsite("https://example-.cc/careers")); // label ends with dash
+        assertFalse(Website.isValidWebsite("https://example@.cc/careers")); // illegal special char
 
         // valid websites
-        assertTrue(Website.isValidWebsite("http://careers.google.com/jobs/results")); // unsafe url
+        assertTrue(Website.isValidWebsite("http://careers.google.com")); // unsafe url
+        assertTrue(Website.isValidWebsite("https://careers.google.com")); // safe url
         assertTrue(Website.isValidWebsite("https://www.amazon.jobs/results/115402744447017670/"));
         assertTrue(Website.isValidWebsite("https://example.com/web/jobs"));
-        assertTrue(Website.isValidWebsite("https://example.sg/careers/swe"));
+        assertTrue(Website.isValidWebsite("https://example.com/")); // ends with slash
+        assertTrue(Website.isValidWebsite("https://example.com")); // no paths
+        assertTrue(Website.isValidWebsite("https://123.com")); // numbers label
+        assertTrue(Website.isValidWebsite("https://123.12m")); // top domain label with numbers
+        assertTrue(Website.isValidWebsite("https://e.oo/results/115402744447017670/")); // minimum domain labels
+        assertTrue(Website.isValidWebsite("https://exam123ple.sg/careers.swe")); // domain name with numbers
     }
 }

--- a/src/test/java/seedu/phu/model/internship/WebsiteTest.java
+++ b/src/test/java/seedu/phu/model/internship/WebsiteTest.java
@@ -38,6 +38,10 @@ public class WebsiteTest {
         assertFalse(Website.isValidWebsite("https://example..eg.cc/careers")); // consecutive period
         assertFalse(Website.isValidWebsite("https://example-.eg.cc/careers")); // consecutive special char
         assertFalse(Website.isValidWebsite("https://example-.cc/careers")); // label ends with dash
+        assertFalse(Website.isValidWebsite("https://example-cc")); // dash before top level domain
+        assertFalse(Website.isValidWebsite("https://-123.com")); // start with dash
+        assertFalse(Website.isValidWebsite("https://test.com-")); // ends with dash
+        assertFalse(Website.isValidWebsite("https://example-cc/careers")); // dash before top level domain
         assertFalse(Website.isValidWebsite("https://example@.cc/careers")); // illegal special char
 
         // valid websites


### PR DESCRIPTION
Web must be of the format `PROTOCOL://DOMAIN-NAME/PATH-QUERY-FRAGMENT` and adhere to the following constraints:
1. The protocol must either be "https" or "http".
2. The domain name is made up of domain labels separated by periods. 
The domain name must:
 - have at least 2 domain labels, with the last label being the top level domain label.
 - have the top level domain label ends with an alphabet.
 - have the top level domain label at least 2 characters long.
 - have the top level domain label separated from the other domain labels by a period.
 - have each domain label start and end with alphanumeric characters.
 - have each domain label consist of alphanumeric characters, separated only by hyphens, if any.
3. The path-query-fragment should only contain alphanumeric characters and these special characters, excluding the outer parentheses, ( ;,/?:@&=+$-_.!~*'()#).
4. Web must not exceed 2048 characters.